### PR TITLE
Workaround the win32 udp bind issues

### DIFF
--- a/py3/pycos/__init__.py
+++ b/py3/pycos/__init__.py
@@ -261,30 +261,32 @@ class _AsyncSocket(object):
         self._blocking = blocking
         if self._blocking:
             self._unregister()
-            self._rsock.setblocking(1)
-            if self._certfile:
-                self._rsock = ssl.wrap_socket(self._rsock, keyfile=self._keyfile,
-                                              certfile=self._certfile,
-                                              ssl_version=self._ssl_version)
-            for name in ['recv', 'send', 'recvfrom', 'sendto', 'accept', 'connect']:
-                setattr(self, name, getattr(self._rsock, name))
-            if self._rsock.type & socket.SOCK_STREAM:
-                self.recvall = self._sync_recvall
-                self.sendall = self._sync_sendall
-                self.recv_msg = self._sync_recv_msg
-                self.send_msg = self._sync_send_msg
-                self.accept = self._sync_accept
+            if self._rsock is not None:
+                self._rsock.setblocking(1)
+                if self._certfile:
+                    self._rsock = ssl.wrap_socket(self._rsock, keyfile=self._keyfile,
+                                                  certfile=self._certfile,
+                                                  ssl_version=self._ssl_version)
+                for name in ['recv', 'send', 'recvfrom', 'sendto', 'accept', 'connect']:
+                    setattr(self, name, getattr(self._rsock, name))
+                if self._rsock.type & socket.SOCK_STREAM:
+                    self.recvall = self._sync_recvall
+                    self.sendall = self._sync_sendall
+                    self.recv_msg = self._sync_recv_msg
+                    self.send_msg = self._sync_send_msg
+                    self.accept = self._sync_accept
             self._scheduler = None
             self._notifier = None
         else:
-            self._rsock.setblocking(0)
+            if self._rsock is not None:
+                self._rsock.setblocking(0)
             self.recv = self._async_recv
             self.send = self._async_send
             self.recvfrom = self._async_recvfrom
             self.sendto = self._async_sendto
             self.accept = self._async_accept
             self.connect = self._async_connect
-            if self._rsock.type & socket.SOCK_STREAM:
+            if self._rsock is not None and self._rsock.type & socket.SOCK_STREAM:
                 self.recvall = self._async_recvall
                 self.sendall = self._async_sendall
                 self.recv_msg = self._async_recv_msg

--- a/py3/pycos/netpycos.py
+++ b/py3/pycos/netpycos.py
@@ -8,6 +8,7 @@ import socket
 import inspect
 import traceback
 import os
+import sys
 import stat
 import hashlib
 import collections
@@ -222,6 +223,8 @@ class Pycos(pycos.Pycos, metaclass=Singleton):
                 mreq += struct.pack('@I', addrinfo.ifn)
                 udp_sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_JOIN_GROUP, mreq)
 
+            if sys.platform.startswith('win'):
+                bind_addr = ''
             udp_sock.bind((bind_addr, udp_port))
             if addrinfo.family == socket.AF_INET6:
                 try:


### PR DESCRIPTION
Hi!

On win32 I'm getting this error on udp bind:

```
2018-06-19 13:29:26 pycos - Could not load pywin32 for I/O Completion Ports; using inefficient polling for sockets
2018-06-19 13:29:26 pycos - version 4.7.0 with select I/O notifier
2018-06-19 13:29:26 pycos - version 4.7.0 with select I/O notifier
2018-06-19 13:29:26 pycos - TCP server "maxl-lt" @ 127.0.0.1:9705
Traceback (most recent call last):
  File "adhoc/pycos/t1.py", line 14, in <module>
    sched = pycos.Pycos(node="127.0.0.1")
  File "c:\users\maxl\work\personal\tmp\pycos\py3\pycos\__init__.py", line 87, in __call__
    Singleton._memo[cls] = super(Singleton, cls).__call__(*args, **kwargs)
  File "c:\users\maxl\work\personal\tmp\pycos\py3\pycos\netpycos.py", line 228, in __init__
    udp_sock.bind((bind_addr, udp_port))
OSError: [WinError 10049] The requested address is not valid in its context

```
I'm creating scheduler like this:
`    sched = pycos.Pycos(node="127.0.0.1")
`

On udp_sock.bind execution, bind_addr equals '127.255.255.255', which makes winsock fail to bind. On linux, the same code works fine.

Probably, my solution is not the best, but it works for me. If you need more testing of other solutions for this issue, I'll be glad to help