### PR TITLE
Handling the situations when _rsock is None

### DIFF
--- a/py3/pycos/__init__.py
+++ b/py3/pycos/__init__.py
@@ -261,30 +261,32 @@ class _AsyncSocket(object):
         self._blocking = blocking
         if self._blocking:
             self._unregister()
-            self._rsock.setblocking(1)
-            if self._certfile:
-                self._rsock = ssl.wrap_socket(self._rsock, keyfile=self._keyfile,
-                                              certfile=self._certfile,
-                                              ssl_version=self._ssl_version)
-            for name in ['recv', 'send', 'recvfrom', 'sendto', 'accept', 'connect']:
-                setattr(self, name, getattr(self._rsock, name))
-            if self._rsock.type & socket.SOCK_STREAM:
-                self.recvall = self._sync_recvall
-                self.sendall = self._sync_sendall
-                self.recv_msg = self._sync_recv_msg
-                self.send_msg = self._sync_send_msg
-                self.accept = self._sync_accept
+            if self._rsock is not None:
+                self._rsock.setblocking(1)
+                if self._certfile:
+                    self._rsock = ssl.wrap_socket(self._rsock, keyfile=self._keyfile,
+                                                  certfile=self._certfile,
+                                                  ssl_version=self._ssl_version)
+                for name in ['recv', 'send', 'recvfrom', 'sendto', 'accept', 'connect']:
+                    setattr(self, name, getattr(self._rsock, name))
+                if self._rsock.type & socket.SOCK_STREAM:
+                    self.recvall = self._sync_recvall
+                    self.sendall = self._sync_sendall
+                    self.recv_msg = self._sync_recv_msg
+                    self.send_msg = self._sync_send_msg
+                    self.accept = self._sync_accept
             self._scheduler = None
             self._notifier = None
         else:
-            self._rsock.setblocking(0)
+            if self._rsock is not None:
+                self._rsock.setblocking(0)
             self.recv = self._async_recv
             self.send = self._async_send
             self.recvfrom = self._async_recvfrom
             self.sendto = self._async_sendto
             self.accept = self._async_accept
             self.connect = self._async_connect
-            if self._rsock.type & socket.SOCK_STREAM:
+            if self._rsock is not None and self._rsock.type & socket.SOCK_STREAM:
                 self.recvall = self._async_recvall
                 self.sendall = self._async_sendall
                 self.recv_msg = self._async_recv_msg


### PR DESCRIPTION
Hi!

Getting this error on program termination:
<pre>
Traceback (most recent call last):
  File "C:\Users\maxl\Anaconda3\envs\nips_run2\lib\threading.py", line 916, in _bootstrap_inner
    self.run()
  File "C:\Users\maxl\Anaconda3\envs\nips_run2\lib\threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "c:\users\maxl\work\personal\tmp\pycos\py3\pycos\__init__.py", line 3911, in _schedule
    self._notifier.terminate()
  File "c:\users\maxl\work\personal\tmp\pycos\py3\pycos\__init__.py", line 1885, in terminate
    setblocking(True)
  File "c:\users\maxl\work\personal\tmp\pycos\py3\pycos\__init__.py", line 264, in setblocking
    self._rsock.setblocking(1)
AttributeError: 'NoneType' object has no attribute 'setblocking'
</pre>
