### PR TITLE
Add missing import

### DIFF
--- a/py2/pycos/dispycos.py
+++ b/py2/pycos/dispycos.py
@@ -23,6 +23,7 @@ import operator
 import functools
 import re
 import copy
+import stat
 
 import pycos
 import pycos.netpycos


### PR DESCRIPTION
`stat` module is missing in `py2` version (but exists in `py3`).