### PR TITLE
Make node load calculation more safe

### DIFF
--- a/py2/pycos/dispycos.py
+++ b/py2/pycos/dispycos.py
@@ -732,7 +732,8 @@ class Scheduler(object):
                     if job.cpu:
                         self.cpu_avail.set()
                         node.cpus_used -= 1
-                        node.load = float(node.cpus_used) / len(node.servers)
+                        node.load = ((float(node.cpus_used) / len(node.servers))
+                                     if node.servers else 0.0)
                         self.scheduler._cpu_nodes.add(node)
                         self.scheduler._cpus_avail.set()
                         node.cpu_avail.set()
@@ -837,7 +838,8 @@ class Scheduler(object):
                 job = info[1]
                 if job.cpu:
                     node.cpus_used -= 1
-                    node.load = float(node.cpus_used) / len(node.servers)
+                    node.load = ((float(node.cpus_used) / len(node.servers))
+                                 if node.servers else 0.0)
                     self._cpu_nodes.add(node)
                     self._cpus_avail.set()
                     node.cpu_avail.set()
@@ -979,7 +981,8 @@ class Scheduler(object):
                         self._cpu_nodes.add(node)
                         self._cpus_avail.set()
                         node.cpu_avail.set()
-                        node.load = float(node.cpus_used) / len(node.servers)
+                        node.load = ((float(node.cpus_used) / len(node.servers))
+                                     if node.servers else 0.0)
                         if self._cur_computation and self._cur_computation.status_task:
                             self._cur_computation.status_task.send(
                                 DispycosStatus(server.status, server.task.location))
@@ -1339,7 +1342,8 @@ class Scheduler(object):
             if cpu:
                 server.cpu_avail.clear()
                 node.cpus_used += 1
-                node.load = float(node.cpus_used) / len(node.servers)
+                node.load = ((float(node.cpus_used) / len(node.servers))
+                             if node.servers else 0.0)
                 if node.cpus_used == len(node.servers):
                     node.cpu_avail.clear()
                     self._cpu_nodes.discard(node)
@@ -1375,7 +1379,8 @@ class Scheduler(object):
             if cpu:
                 server.cpu_avail.clear()
                 node.cpus_used += 1
-                node.load = float(node.cpus_used) / len(node.servers)
+                node.load = ((float(node.cpus_used) / len(node.servers))
+                             if node.servers else 0.0)
                 if node.cpus_used >= len(node.servers):
                     node.cpu_avail.clear()
                     self._cpu_nodes.discard(node)
@@ -1399,7 +1404,8 @@ class Scheduler(object):
                         raise StopIteration
                 server.cpu_avail.clear()
                 node.cpus_used += 1
-                node.load = float(node.cpus_used) / len(node.servers)
+                node.load = ((float(node.cpus_used) / len(node.servers))
+                             if node.servers else 0.0)
                 if node.cpus_used >= len(node.servers):
                     node.cpu_avail.clear()
                     self._cpu_nodes.discard(node)

--- a/py3/pycos/dispycos.py
+++ b/py3/pycos/dispycos.py
@@ -736,7 +736,8 @@ class Scheduler(object, metaclass=pycos.Singleton):
                     if job.cpu:
                         self.cpu_avail.set()
                         node.cpus_used -= 1
-                        node.load = float(node.cpus_used) / len(node.servers)
+                        node.load = ((float(node.cpus_used) / len(node.servers))
+                                     if node.servers else 0.0)
                         self.scheduler._cpu_nodes.add(node)
                         self.scheduler._cpus_avail.set()
                         node.cpu_avail.set()
@@ -841,7 +842,8 @@ class Scheduler(object, metaclass=pycos.Singleton):
                 job = info[1]
                 if job.cpu:
                     node.cpus_used -= 1
-                    node.load = float(node.cpus_used) / len(node.servers)
+                    node.load = ((float(node.cpus_used) / len(node.servers))
+                                 if node.servers else 0.0)
                     self._cpu_nodes.add(node)
                     self._cpus_avail.set()
                     node.cpu_avail.set()
@@ -984,7 +986,8 @@ class Scheduler(object, metaclass=pycos.Singleton):
                         self._cpu_nodes.add(node)
                         self._cpus_avail.set()
                         node.cpu_avail.set()
-                        node.load = float(node.cpus_used) / len(node.servers)
+                        node.load = ((float(node.cpus_used) / len(node.servers))
+                                     if node.servers else 0.0)
                         if self._cur_computation and self._cur_computation.status_task:
                             self._cur_computation.status_task.send(
                                 DispycosStatus(server.status, server.task.location))
@@ -1344,7 +1347,8 @@ class Scheduler(object, metaclass=pycos.Singleton):
             if cpu:
                 server.cpu_avail.clear()
                 node.cpus_used += 1
-                node.load = float(node.cpus_used) / len(node.servers)
+                node.load = ((float(node.cpus_used) / len(node.servers))
+                             if node.servers else 0.0)
                 if node.cpus_used == len(node.servers):
                     node.cpu_avail.clear()
                     self._cpu_nodes.discard(node)
@@ -1380,7 +1384,8 @@ class Scheduler(object, metaclass=pycos.Singleton):
             if cpu:
                 server.cpu_avail.clear()
                 node.cpus_used += 1
-                node.load = float(node.cpus_used) / len(node.servers)
+                node.load = ((float(node.cpus_used) / len(node.servers))
+                             if node.servers else 0.0)
                 if node.cpus_used >= len(node.servers):
                     node.cpu_avail.clear()
                     self._cpu_nodes.discard(node)
@@ -1404,7 +1409,8 @@ class Scheduler(object, metaclass=pycos.Singleton):
                         raise StopIteration
                 server.cpu_avail.clear()
                 node.cpus_used += 1
-                node.load = float(node.cpus_used) / len(node.servers)
+                node.load = ((float(node.cpus_used) / len(node.servers))
+                             if node.servers else 0.0)
                 if node.cpus_used >= len(node.servers):
                     node.cpu_avail.clear()
                     self._cpu_nodes.discard(node)


### PR DESCRIPTION
It's possible what `node.servers` is empty. For example, if terminate `dispycosnode.py` in command mode. This PR updates all node's load calcs to prevent `ZeroDivisionError` exception.