### PR TITLE
Accept Location in the Scheduler nodes param

### DIFF
--- a/py2/pycos/dispycos.py
+++ b/py2/pycos/dispycos.py
@@ -776,7 +776,9 @@ class Scheduler(object):
         self.__client_task = SysTask(self.__client_proc)
         self.__client_task.register('dispycos_scheduler')
         for node in nodes:
-            Task(self.pycos.peer, pycos.Location(node, self._node_port), relay=relay_nodes)
+            if not isinstance(node, pycos.Location):
+                node = pycos.Location(node, self._node_port)
+            Task(self.pycos.peer, node, relay=relay_nodes)
 
     def status(self):
         pending_cpu = sum(node.cpus_used for node in self._nodes.itervalues())

--- a/py3/pycos/dispycos.py
+++ b/py3/pycos/dispycos.py
@@ -780,7 +780,9 @@ class Scheduler(object, metaclass=pycos.Singleton):
         self.__client_task = SysTask(self.__client_proc)
         self.__client_task.register('dispycos_scheduler')
         for node in nodes:
-            Task(self.pycos.peer, pycos.Location(node, self._node_port), relay=relay_nodes)
+            if not isinstance(node, pycos.Location):
+                node = pycos.Location(node, self._node_port)
+            Task(self.pycos.peer, node, relay=relay_nodes)
 
     def status(self):
         pending_cpu = sum(node.cpus_used for node in self._nodes.values())


### PR DESCRIPTION
`Scheduler` fails if pass `Location` in nodes param:
```python
Scheduler(nodes=[Location(...), ...]
```
This PR allows to handle both strings and `Location` objects.