### PR TITLE
Send NodeAbandoned status for zombie nodes

### DIFF
--- a/py2/pycos/dispycos.py
+++ b/py2/pycos/dispycos.py
@@ -1663,6 +1663,12 @@ class Scheduler(object):
         computation = self._cur_computation
         disconnected = node.addr not in self._nodes
         if disconnected:
+            if (node.addr in self._disabled_nodes and computation
+                    and computation.status_task):
+                node.status = Scheduler.NodeAbandoned
+                info = DispycosNodeInfo(node.name, node.addr, node.cpus,
+                                        node.platform, node.avail_info)
+                computation.status_task.send(DispycosStatus(node.status, info))
             servers = node.servers.values()
             disabled_servers = node.disabled_servers.values()
             node.servers.clear()

--- a/py3/pycos/dispycos.py
+++ b/py3/pycos/dispycos.py
@@ -1668,6 +1668,12 @@ class Scheduler(object, metaclass=pycos.Singleton):
         computation = self._cur_computation
         disconnected = node.addr not in self._nodes
         if disconnected:
+            if (node.addr in self._disabled_nodes and computation
+                    and computation.status_task):
+                node.status = Scheduler.NodeAbandoned
+                info = DispycosNodeInfo(node.name, node.addr, node.cpus,
+                                        node.platform, node.avail_info)
+                computation.status_task.send(DispycosStatus(node.status, info))
             servers = list(node.servers.values())
             disabled_servers = list(node.disabled_servers.values())
             node.servers.clear()


### PR DESCRIPTION
`Scheduler` doesn't send `NodeAbandoned` status when closes zombie node. Not critical, but can be useful to implement fault-tolerant workflows.

I'm not sure if I do it correctly because `self._disabled_nodes` updates in many places. Maybe better to move the notification to `__timer_proc()` before calling `SysTask(self.__close_node, node)`.
Review please.