### PR TITLE
Suppress nodes discovering if discover_peers is not set

### DIFF
--- a/py2/pycos/netpycos.py
+++ b/py2/pycos/netpycos.py
@@ -267,8 +267,9 @@ class Pycos(pycos.Pycos):
         self._signature = self._signature.hexdigest()
         self._auth_code = hashlib.sha1((self._signature + secret).encode()).hexdigest()
         pycos.Task._sign = pycos.Channel._sign = SysTask._sign = RTI._sign = self._signature
-        if discover_peers:
-            self.discover_peers()
+
+        self._discover_peers = discover_peers
+        self.discover_peers()
 
     @classmethod
     def instance(cls, *args, **kwargs):
@@ -437,11 +438,17 @@ class Pycos(pycos.Pycos):
             ping_sock.close()
         raise StopIteration(0)
 
-    def discover_peers(self, port=None):
+    def discover_peers(self, port=None, force=False):
         """This method can be invoked (periodically?) to broadcast message to
         discover peers, if there is a chance initial broadcast message may be
         lost (as these messages are sent over UDP).
+
+        This method does nothing if 'discover_peers' passed to the constructor
+        is 'False'; unless 'force=True'.
         """
+        if not self._discover_peers and not force:
+            return
+
         ping_msg = {'signature': self._signature, 'name': self._name, 'version': __version__}
 
         def _discover(addrinfo, port, task=None):


### PR DESCRIPTION
`pycos` discovers all nodes even if you pass `discover_peers=False`.

Test code:
```python
from pycos.dispycos import Scheduler, Computation, Task
from pycos.netpycos import Location


def compute(client, index, task=None):
    for i in range(3):
        client.send("[%s] working %d:%d" % (task.location, index, i))
        yield task.sleep(1)


def response_proc(task=None):
    task.set_daemon()
    while True:
        result = yield task.receive()
        print(result)


def client(njobs, task=None):
    computation = Computation([compute])

    if (yield computation.schedule()):
        raise Exception('Could not schedule computation')

    args = [1, 2, 3]
    response_task = Task(response_proc)
    yield computation.run_results(compute, ((response_task, x) for x in args))
    yield computation.close()


if __name__ == '__main__':
    scheduler = Scheduler(
        node='172.27.0.1',
        nodes=[Location('172.27.0.101', 9706), Location('172.27.0.102', 9706)],
        discover_peers=False,
        relay_nodes=False)
    Task(client, 3)
```
This code runs 3 computations in parallel, but only two parallel runs expected, because there are two nodes specified. The IPs belongs to docker containers. I run 3 containers locally.

Log:
```
2018-12-18 17:09:20 dispycos - version 4.8.6 with epoll I/O notifier
2018-12-18 17:09:20 dispycos - TCP server "dispycos_scheduler" @ 172.27.0.1:9705
2018-12-18 17:09:20 dispycos - UDP server @ <broadcast>:9705
[172.27.0.103:9707] working 1:0
[172.27.0.102:9707] working 2:0
[172.27.0.101:9707] working 3:0
[172.27.0.103:9707] working 1:1
[172.27.0.102:9707] working 2:1
[172.27.0.101:9707] working 3:1
[172.27.0.103:9707] working 1:2
[172.27.0.102:9707] working 2:2
[172.27.0.101:9707] working 3:2
```

Fixed version log:
```
2018-12-18 17:09:42 dispycos - version 4.8.6 with epoll I/O notifier
2018-12-18 17:09:42 dispycos - TCP server "dispycos_scheduler" @ 172.27.0.1:9705
2018-12-18 17:09:42 dispycos - UDP server @ <broadcast>:9705
[172.27.0.102:9707] working 1:0
[172.27.0.101:9707] working 2:0
[172.27.0.102:9707] working 1:1
[172.27.0.101:9707] working 2:1
[172.27.0.102:9707] working 1:2
[172.27.0.101:9707] working 2:2
[172.27.0.102:9707] working 3:0
[172.27.0.102:9707] working 3:1
[172.27.0.102:9707] working 3:2
2018-12-18 17:09:48 dispycos - Status 15 for server 172.27.0.102:9707 is ignored
```