### PR TITLE
Fix TaskAbandoned notification on server disconnection

### DIFF
--- a/py2/dispycos.py
+++ b/py2/dispycos.py
@@ -1805,8 +1805,9 @@ class Scheduler(object):
                 # TODO: send Abandoned if node is zombie as well?
                 if server.status == Scheduler.ServerDisconnected:
                     for rtask, job in server.rtasks.itervalues():
-                        status = pycos.MonitorException(rtask, (Scheduler.TaskAbandoned, None))
-                        status_task.send(status)
+                        if status_task:
+                            status = pycos.MonitorException(rtask, (Scheduler.TaskAbandoned, None))
+                            status_task.send(status)
                         if job.request.endswith('async'):
                             if job.done:
                                 job.done.set()

--- a/py3/dispycos.py
+++ b/py3/dispycos.py
@@ -1813,8 +1813,9 @@ class Scheduler(object, metaclass=pycos.Singleton):
                 # TODO: send Abandoned if node is zombie as well?
                 if server.status == Scheduler.ServerDisconnected:
                     for rtask, job in server.rtasks.values():
-                        status = pycos.MonitorException(rtask, (Scheduler.TaskAbandoned, None))
-                        status_task.send(status)
+                        if status_task:
+                            status = pycos.MonitorException(rtask, (Scheduler.TaskAbandoned, None))
+                            status_task.send(status)
                         if job.request.endswith('async'):
                             if job.done:
                                 job.done.set()


### PR DESCRIPTION
`dispycos` fails to send `TaskAbandoned` message when closes a server:
```
2020-02-18 12:00:57 dispycos - uncaught exception in ~__close_server/140619151847208:
Traceback (most recent call last):
  File "/home/skozlovf/anaconda2/envs/deepfinance/lib/python2.7/site-packages/pycos/__init__.py", line 3610, in _schedule
    retval = task._generator.send(task._value)
  File "/home/skozlovf/anaconda2/envs/deepfinance/lib/python2.7/site-packages/pycos/dispycos.py", line 1809, in __close_server
    status_task.send(status)
AttributeError: 'NoneType' object has no attribute 'send'
```

This PR adds missing `status_task` checking.